### PR TITLE
Dokkaebi now counters Echo, changes made

### DIFF
--- a/src/main/create-operator-json/operators/dokkaebi.js
+++ b/src/main/create-operator-json/operators/dokkaebi.js
@@ -8,6 +8,7 @@ import r6operators from "r6operators";
 let dokkaebi = new Operator(r6operators.dokkaebi, operatorId.dokkaebi, "Operation White Noise");
 
 dokkaebi.addCounterNode(operatorId.maestro, counterType.soft, "Dokkaebi can hack a defender's phone to gain access to the Maestro's Evil Eye cameras. She cannot fire his cameras, however.");
+dokkaebi.addCounterNode(operatorId.echo, counterType.soft, "Dokkaebi can hack a defender's phone to gain access to the view granted by the Yokai cameras.");
 dokkaebi.addCounterNode(operatorId.valkyrie, counterType.hard, "Dokkaebi can hack a defender's phone to gain access to Valkyrie's Black Eyes.");
 dokkaebi.addCounterNode(operatorId.mozzie, counterType.minor, "Dokkaebi can hack a defender's phone to gain access to drones hacked by Mozzie's Pests. Attackers, however, will not regain movement control of the drones.");
 dokkaebi.addCounterNode(operatorId.caviera, counterType.minor, "Dokkaebi can use her Logic Bomb to ring Caveria's phone. This will reveal Caveria's position when roaming even if Silent Step is active.");

--- a/src/main/create-operator-json/operators/echo.js
+++ b/src/main/create-operator-json/operators/echo.js
@@ -7,7 +7,6 @@ import r6operators from "r6operators";
 
 let echo = new Operator(r6operators.echo, operatorId.echo, "Operation Red Crow");
 
-echo.addCounterNode(operatorId.dokkaebi, counterType.hard, "Echo's Yokai drone camera cannot be hacked by Dokkaebi. Echo does not drop a phone upon death. In addition, Echo is unaffected by Dokkaebi's Logic Bomb.");
 echo.addCounterNode(operatorId.jackal, counterType.soft, "Echo's Yokai drone will cause Jackal's goggles to be kicked off.");
 
 


### PR DESCRIPTION
According to patch Y4S4.3, Echo drops a phone when he dies, and if Dokkaebi hacks a defender phone she gets access to the Yokai cameras as well. 