### PR TITLE
fix smoke's hard counter to montagne

### DIFF
--- a/src/main/create-operator-json/operators/smoke.js
+++ b/src/main/create-operator-json/operators/smoke.js
@@ -7,7 +7,7 @@ import r6operators from "r6operators";
 
 let smoke = new Operator(r6operators.smoke, operatorId.smoke, "N/A");
 
-smoke.addCounterNode(operatorId.rook, counterType.hard, "Smoke's 3 Gas Grenades are very effective against Montagne.");
+smoke.addCounterNode(operatorId.montagne, counterType.hard, "Smoke's 3 Gas Grenades are very effective against Montagne.");
 smoke.addCounterNode(operatorId.blitz, counterType.hard, "Smoke's 3 Gas Grenades are very effective against Blitz.");
 smoke.addCounterNode(operatorId.fuze, counterType.soft, "Smoke's 3 Gas Grenades are very effective against a Fuze with a shield.");
 smoke.addCounterNode(operatorId.finka, counterType.soft, "Smoke's Gas Grenades deal 50% more damage to Attackers boosted by Finka's Adrenal Surge.");


### PR DESCRIPTION
Fixes smoke's hard counter to Montagne.
Resolves #185 

After building and running it should look something like this when hovering over hard counter connection:
![image](https://user-images.githubusercontent.com/17718280/94875350-67f10e80-0409-11eb-96e1-f17120d4aff3.png)
