### PR TITLE
Fix compositing performance (3x improvement)

### DIFF
--- a/src/main/scripts/neo4jd3.js
+++ b/src/main/scripts/neo4jd3.js
@@ -646,57 +646,6 @@ function Neo4jD3(_selector, _options) {
         return graph;
     }
 
-    function randomD3Data(d, maxNodesToGenerate) {
-        var data = {
-                nodes: [],
-                relationships: []
-            },
-            i,
-            label,
-            node,
-            numNodes = (maxNodesToGenerate * Math.random() << 0) + 1,
-            relationship,
-            s = size();
-
-        for (i = 0; i < numNodes; i++) {
-            label = randomLabel();
-
-            node = {
-                id: s.nodes + 1 + i,
-                labels: [label],
-                properties: {
-                    random: label
-                },
-                x: d.x,
-                y: d.y
-            };
-
-            data.nodes[data.nodes.length] = node;
-
-            relationship = {
-                id: s.relationships + 1 + i,
-                type: label.toUpperCase(),
-                startNode: d.id,
-                endNode: s.nodes + 1 + i,
-                properties: {
-                    from: Date.now()
-                },
-                source: d.id,
-                target: s.nodes + 1 + i,
-                linknum: s.relationships + 1 + i
-            };
-
-            data.relationships[data.relationships.length] = relationship;
-        }
-
-        return data;
-    }
-
-    function randomLabel() {
-        var icons = Object.keys(options.iconMap);
-        return icons[icons.length * Math.random() << 0];
-    }
-
     function rotate(cx, cy, x, y, angle) {
         var radians = (Math.PI / 180) * angle,
             cos = Math.cos(radians),
@@ -1033,7 +982,6 @@ function Neo4jD3(_selector, _options) {
 
     return {
         neo4jDataToD3Data: neo4jDataToD3Data,
-        randomD3Data: randomD3Data,
         size: size,
         updateWithD3Data: updateWithD3Data,
         updateWithNeo4jData: updateWithNeo4jData,

--- a/src/main/styles/neo4jd3.scss
+++ b/src/main/styles/neo4jd3.scss
@@ -174,10 +174,14 @@ body {
 }
 
 .node {
+    will-change: transform;
+
     transition: opacity 0.5s;
 }
 
 .relationship {
+    will-change: transform;
+
     transition: opacity 0.5s;
     cursor: default;
 


### PR DESCRIPTION
### How to test
Comment out `tickRelationshipOutlines();` in `neo4jd3.js` like this:
``` js
            tickRelationshipsTexts();
            //tickRelationshipsOutlines();
            tickRelationshipsOverlays();
```

This removes other bottlenecks. Compare the performance of dragging around icons before vs after this change.

Before (75ms total task time~, around 50ms is compositing):
![image](https://user-images.githubusercontent.com/7528322/165595115-f3bb3598-278d-42b4-ad0b-09ec5c079740.png)

After (25ms total task time~, around 1ms is composting):
![image](https://user-images.githubusercontent.com/7528322/165595521-bb3fbdb2-4406-48c0-93d3-81164a8a370e.png)

Reference: https://stackoverflow.com/a/40533907/3991315