### PR TITLE
Settings saved in local storage

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -49,15 +49,15 @@
         <button id="toolsButton" aria-label="Tools and settings button"></button>
 
         <div class="checkboxes">
-			<input type="checkbox" id="hardCounters" class="counterCheckbox" checked> 
+			<input type="checkbox" id="hardCounters" class="counterCheckbox">
             <label for="hardCounters" class="hardcounter">Hard counters</label>
             <br>
 
-			<input type="checkbox" id="softCounters" class="counterCheckbox"> 
+			<input type="checkbox" id="softCounters" class="counterCheckbox">
 			<label for="softCounters" class="softcounter">Soft counters</label>
             <br>
 
-			<input type="checkbox" id="minorCounters" class="counterCheckbox"> 
+			<input type="checkbox" id="minorCounters" class="counterCheckbox">
 			<label for="minorCounters" class="minorcounter">Minor counters</label>
         </div>
 

--- a/src/main/scripts/app.js
+++ b/src/main/scripts/app.js
@@ -3,11 +3,24 @@ import ImageLocation from './imageLocation.js'
 
 // local storage and default settings initialisation
 var highAccuracySimulation = true;
+var counters = [
+    true,   // hard counters
+    false,  // soft counters
+    false   // minor counters
+];
+
 if(localStorage.getItem('highAccuracySimulation') !== null) {
     highAccuracySimulation = localStorage.getItem('highAccuracySimulation') === 'true';
 } else {
     localStorage.setItem('highAccuracySimulation', highAccuracySimulation);
 }
+
+if(localStorage.getItem('countersSettings') !== null) {
+    counters = JSON.parse(localStorage.getItem('countersSettings'));
+} else {
+    localStorage.setItem('countersSettings', JSON.stringify(counters));
+}
+
 let neo4jd3;
 let neo4jd3Options = {
         highlight: [
@@ -17,11 +30,7 @@ let neo4jd3Options = {
         minCollision: 80,
         neo4jDataUrl: 'json/r6OperatorCounters.json',
         nodeRadius: 35,
-        counters: [
-            document.querySelector('#hardCounters').checked,
-            document.querySelector('#softCounters').checked,
-            document.querySelector('#minorCounters').checked
-        ],
+        counters: counters,
         onNodeDoubleClick: focusOnNode,
         onRelationshipDoubleClick: focusOnRelationship,
         zoomFit: false,
@@ -50,11 +59,13 @@ function init() {
     startButton.style.display = "none";
     stopButton.style.display = "block";
 
-    neo4jd3Options.counters = [
+    let countersSettings = [
         document.querySelector('#hardCounters').checked,
         document.querySelector('#softCounters').checked,
         document.querySelector('#minorCounters').checked,
-    ];
+    ]
+
+    neo4jd3Options.counters = countersSettings;
     neo4jd3Options.simulationQuality = highAccuracySimulation ? 2 : 1;
 
     if (neo4jd3) {
@@ -65,6 +76,9 @@ function init() {
     neo4jd3 = new Neo4jD3('#neo4jd3', neo4jd3Options);
 
     document.querySelector('.neo4jd3-graph').addEventListener('click', unfocus);
+
+    // save counters settings to local storage
+    localStorage.setItem('countersSettings', JSON.stringify(countersSettings));
 }
 
 function focusOnNode(node) {
@@ -172,4 +186,11 @@ function setImages() {
 
 // set the simulation accuracy label
 setAccuracySimLabels();
+
+// set counters checkbox values
+let checkboxes = document.querySelectorAll('div.checkboxes input[type="checkbox"]');
+checkboxes.forEach((checkbox, index) => {
+    checkbox.checked = counters[index];
+});
+
 window.onload = setImages;

--- a/src/main/scripts/app.js
+++ b/src/main/scripts/app.js
@@ -1,6 +1,13 @@
 import Neo4jD3 from './neo4jd3.js';
 import ImageLocation from './imageLocation.js'
 
+// local storage and default settings initialisation
+var highAccuracySimulation = true;
+if(localStorage.getItem('highAccuracySimulation') !== null) {
+    highAccuracySimulation = localStorage.getItem('highAccuracySimulation') === 'true';
+} else {
+    localStorage.setItem('highAccuracySimulation', highAccuracySimulation);
+}
 let neo4jd3;
 let neo4jd3Options = {
         highlight: [
@@ -18,6 +25,7 @@ let neo4jd3Options = {
         onNodeDoubleClick: focusOnNode,
         onRelationshipDoubleClick: focusOnRelationship,
         zoomFit: false,
+        simulationQuality: highAccuracySimulation ? 2 : 1
     };
 
 //event listeners to handle clicks, module is not global scoped
@@ -132,11 +140,7 @@ function freezeAllNodes() {
     neo4jd3.freezeAllNodes();
 }
 
-var highAccuracySimulation = true;
-
-function toggleSimulationAccuracy() {
-    highAccuracySimulation = !highAccuracySimulation;
-
+function setAccuracySimLabels() {
     if (highAccuracySimulation) {
         highAccuracySimEnabledLabel.style.display = "block";
         highAccuracySimDisabledLabel.style.display = "none";
@@ -144,6 +148,14 @@ function toggleSimulationAccuracy() {
         highAccuracySimEnabledLabel.style.display = "none";
         highAccuracySimDisabledLabel.style.display = "block";
     }
+}
+
+function toggleSimulationAccuracy() {
+    highAccuracySimulation = !highAccuracySimulation;
+
+    setAccuracySimLabels();
+
+    localStorage.setItem('highAccuracySimulation', highAccuracySimulation);
 
     // re-load the graph with the new simulation quality
     init();
@@ -158,4 +170,6 @@ function setImages() {
     init();
 }
 
+// set the simulation accuracy label
+setAccuracySimLabels();
 window.onload = setImages;

--- a/src/main/scripts/app.js
+++ b/src/main/scripts/app.js
@@ -188,8 +188,8 @@ function setImages() {
 setAccuracySimLabels();
 
 // set counters checkbox values
-let checkboxes = document.querySelectorAll('div.checkboxes input[type="checkbox"]');
-checkboxes.forEach((checkbox, index) => {
+let countersCheckboxes = document.querySelectorAll('div.checkboxes input[type="checkbox"]');
+countersCheckboxes.forEach((checkbox, index) => {
     checkbox.checked = counters[index];
 });
 


### PR DESCRIPTION
Resolves #225 

## Changes
- Used local storage to save and restore previously selected settings (simulation quality, counters checkboxes)

## Possible Improvements
- Use a .env file to configure the settings default values