### PR TITLE
Added Jäger vs. Capitão/Gridlock interactions introduced in Y10S2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "lodash": "^4.17.19",
         "node-notifier": "^8.0.2",
         "proxyquireify": "^3.2.0",
-        "r6operators": "^2.10.2",
+        "r6operators": "^2.11.1",
         "sass": "^1.85.0",
         "vinyl-buffer": "^1.0.0",
         "vinyl-source-stream": "^1.1.2",
@@ -58,7 +58,7 @@
         "workbox-build": "^7.3.0"
       },
       "engines": {
-        "node": "13.9.0"
+        "node": "^20.11.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16598,9 +16598,9 @@
       ]
     },
     "node_modules/r6operators": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/r6operators/-/r6operators-2.10.2.tgz",
-      "integrity": "sha512-Rouq6/NTcB6lpyEs4ESQFiIyD4oMcLb5TPDyQuiW6yo7Mrgcu5yxmYA8Y9X4NSS0kZfjI13be8r4tek+FUGKnQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/r6operators/-/r6operators-2.11.1.tgz",
+      "integrity": "sha512-HdUO2nGrmZk46xqshJ+PFssNmz93iZWVZP10f05EN65GkX549PAV9z9fvejQqPDVswJ65LmLHle5DQvGA9WkIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/create-operator-json/operators/jager.js
+++ b/src/main/create-operator-json/operators/jager.js
@@ -18,5 +18,7 @@ jager.addCounterNode(operatorId.kali, counterType.soft, "Jäger's ADS can interc
 jager.addCounterNode(operatorId.zero, counterType.hard, "Jäger's ADS can intercept Zero's Argus cameras.");
 jager.addCounterNode(operatorId.sens, counterType.hard, "Jäger's ADS can intercept Sens' ROU's.");
 jager.addCounterNode(operatorId.grim, counterType.hard, "Jäger's ADS can intercept Grim's Hive Canisters.");
+jager.addCounterNode(operatorId.capitao, counterType.hard, "Jäger's ADS can intercept Capitão's Crossbow Bolts.");
+jager.addCounterNode(operatorId.gridlock, counterType.hard, "Jäger's ADS can intercept Gridlock's Trax Stingers.");
 
 export default jager


### PR DESCRIPTION
Source:
https://www.ubisoft.com/en-us/game/rainbow-six/siege/news-updates/8dJbwMqIt5Y8lZgwJRjWZ/y10s2-designers-notes#:~:text=Capitao%27s%20Incendiary%20and%20Micro%20Smoke%20Bolts%20are%20detected%20and%20destroyed.

Since the start of Y10S2 (i.e. "Siege X"), Jäger's ADS also captures Capitão's bolts and Gridlock's Trax, to align the interaction with Wamai's utility.